### PR TITLE
Improve cool stuff details table layout

### DIFF
--- a/app/cool-stuff/[...id]/page.tsx
+++ b/app/cool-stuff/[...id]/page.tsx
@@ -78,37 +78,34 @@ export default function CoolThing({ params }: { params: Params }) {
         </header>
 
         <Prose className="mt-10">
-          <table>
+          <table className="table-fixed">
             <tbody>
-              <tr>
-                <th scope="row">Date Added</th>
-                <td>
-                  <time dateTime={thing.addedDate}>
-                    {formatDate(thing.addedDate)}
-                  </time>
-                </td>
-              </tr>
-              <tr>
-                <th scope="row">Category</th>
-                <td>{thing.categories.join(', ')}</td>
-              </tr>
-              <tr>
-                <th scope="row">Cool Factor</th>
-                <td>{numberFormat.format(thing.coolFactor)}</td>
-              </tr>
-              <tr>
-                <th scope="row">On This Site</th>
-                <td>{thing.onThisSite ? 'Yes' : 'No'}</td>
-              </tr>
-              <tr>
-                <th scope="row">Website</th>
-                <td>
+              <TableRow header="Date Added">
+                <time dateTime={thing.addedDate}>
+                  {formatDate(thing.addedDate)}
+                </time>
+              </TableRow>
+
+              <TableRow header="Category">
+                {thing.categories.join(', ')}
+              </TableRow>
+
+              <TableRow header="Cool Factor">
+                {numberFormat.format(thing.coolFactor)}
+              </TableRow>
+
+              <TableRow header="On This Site">
+                {thing.onThisSite ? 'Yes' : 'No'}
+              </TableRow>
+
+              <TableRow header="Website">
+                <div className="truncate">
                   <CustomLink
                     href={thing.websiteUrl}
                     showHostnameIfExternal={true}
                   />
-                </td>
-              </tr>
+                </div>
+              </TableRow>
             </tbody>
           </table>
         </Prose>
@@ -116,5 +113,22 @@ export default function CoolThing({ params }: { params: Params }) {
         <Mdx className="mt-10" code={thing.body.code} />
       </article>
     </div>
+  )
+}
+
+function TableRow({
+  header,
+  children,
+}: {
+  header: string
+  children: React.ReactNode
+}) {
+  return (
+    <tr>
+      <th className="w-28 whitespace-nowrap md:w-1/2" scope="row">
+        {header}
+      </th>
+      <td className="text-right md:w-1/2 md:text-left">{children}</td>
+    </tr>
   )
 }

--- a/components/CustomLink.tsx
+++ b/components/CustomLink.tsx
@@ -4,29 +4,36 @@ type CustomLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
   showHostnameIfExternal?: boolean
 }
 
-export function CustomLink(props: CustomLinkProps) {
-  const { href, children, showHostnameIfExternal } = props
-
+export function CustomLink({
+  href,
+  children,
+  showHostnameIfExternal,
+  ...props
+}: CustomLinkProps) {
   if (!href) {
     return <span {...props}>{children}</span>
   }
 
   if (href.startsWith('/')) {
     return (
-      <Link {...props} href={href} ref={undefined}>
+      <Link href={href} ref={undefined} {...props}>
         {children}
       </Link>
     )
   }
 
   if (href.startsWith('#')) {
-    return <a {...props}>{children}</a>
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    )
   }
 
   const { hostname } = new URL(href)
 
   return (
-    <a {...props} target="_blank" rel="noopener noreferrer">
+    <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
       {showHostnameIfExternal ? hostname : children}{' '}
       <span aria-hidden="true">↗</span>
     </a>

--- a/components/Prose.tsx
+++ b/components/Prose.tsx
@@ -13,6 +13,7 @@ export function Prose({ className, children }: ProseProps) {
         'prose-headings:relative prose-headings:scroll-mt-28 lg:prose-headings:scroll-mt-12',
         'prose-a:font-semibold prose-a:text-primary-800 prose-a:underline-offset-2 prose-a:transition-colors hover:prose-a:text-primary-600 dark:prose-a:text-primary-500 dark:hover:prose-a:text-primary-700',
         'prose-p:text-gray-700 dark:prose-p:text-gray-300',
+        'prose-th:font-semibold',
         className
       )}
     >


### PR DESCRIPTION
Improve the styling of the cool stuff details page table:

- Prevent `<th>` wrapping
- Prevent overflowing website links
- Fix React warning about `showHostnameIfExternal` being spread onto `<a>`