### PR TITLE
Improve header styling and hide empty prose

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -44,7 +44,7 @@ const links: HeaderNavLinkProps[] = [
 
 export function Header() {
   return (
-    <header className="sticky top-0 z-50 select-none border-b border-primary-600/10 bg-primary-50/70 backdrop-blur-xl dark:border-primary-900/30 dark:bg-primary-900/20 lg:static lg:row-span-2 lg:border-b-0 lg:border-r lg:backdrop-blur-none">
+    <header className="sticky top-0 z-50 select-none border-b border-primary-600/10 bg-primary-50/70 backdrop-blur-lg backdrop-filter dark:border-primary-900/30 dark:bg-primary-900/20 lg:static lg:row-span-2 lg:border-b-0 lg:border-r lg:backdrop-blur-none">
       <div className="mx-auto flex max-h-[100dvh] items-center justify-center p-4 xs:justify-between lg:sticky lg:top-0 lg:flex-col lg:overflow-y-auto lg:px-0 lg:py-12">
         <Link
           className="lg:dark:border-primary-900/300 hidden text-center xs:block lg:w-full lg:border-b-2 lg:border-primary-600/10"

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -44,7 +44,7 @@ const links: HeaderNavLinkProps[] = [
 
 export function Header() {
   return (
-    <header className="sticky top-0 z-50 select-none border-b border-primary-600/10 bg-primary-50/70 backdrop-blur-lg backdrop-filter dark:border-primary-900/30 dark:bg-primary-900/20 lg:static lg:row-span-2 lg:border-b-0 lg:border-r lg:backdrop-blur-none">
+    <header className="sticky top-0 z-50 select-none border-b border-primary-600/10 bg-primary-50/70 backdrop-blur-lg backdrop-filter dark:border-primary-900/30 dark:bg-primary-900/20 lg:static lg:row-span-2 lg:border-b-0 lg:border-r lg:backdrop-blur-none lg:backdrop-filter-none">
       <div className="mx-auto flex max-h-[100dvh] items-center justify-center p-4 xs:justify-between lg:sticky lg:top-0 lg:flex-col lg:overflow-y-auto lg:px-0 lg:py-12">
         <Link
           className="lg:dark:border-primary-900/300 hidden text-center xs:block lg:w-full lg:border-b-2 lg:border-primary-600/10"

--- a/components/Prose.tsx
+++ b/components/Prose.tsx
@@ -9,7 +9,7 @@ export function Prose({ className, children }: ProseProps) {
   return (
     <div
       className={clsx(
-        'prose prose-lg prose-gray max-w-none dark:prose-invert',
+        'prose prose-lg prose-gray max-w-none dark:prose-invert empty:hidden',
         'prose-headings:relative prose-headings:scroll-mt-28 lg:prose-headings:scroll-mt-12',
         'prose-a:font-semibold prose-a:text-primary-800 prose-a:underline-offset-2 prose-a:transition-colors hover:prose-a:text-primary-600 dark:prose-a:text-primary-500 dark:hover:prose-a:text-primary-700',
         'prose-p:text-gray-700 dark:prose-p:text-gray-300',

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "jasongerbes.com",
       "version": "0.1.0",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@opentelemetry/api": "^1.4.0",
         "@phosphor-icons/react": "^2.0.8",


### PR DESCRIPTION
- Add `background-filter` to site header on < `lg` screens
- Hide the `.prose` components when empty (e.g. for cool stuff without additional details)