### PR TITLE
Add og:image to cool stuff details page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,5 +9,14 @@
         "message": "Use '@/assets/phosphor-icons' instead until RSC support has been added."
       }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/opengraph-image.tsx"],
+      "rules": {
+        "@next/next/no-img-element": "off",
+        "jsx-a11y/alt-text": "off"
+      }
+    }
+  ]
 }

--- a/app/cool-stuff/[id]/opengraph-image.tsx
+++ b/app/cool-stuff/[id]/opengraph-image.tsx
@@ -46,7 +46,7 @@ export default function og({ params }: { params: { id: string } }) {
           {title}
         </p>
 
-        <p tw="text-neutral-400 text-[28px] mt-6">jasongerbes.com/cool-stuff</p>
+        <p tw="text-neutral-400 text-[28px] mt-4">jasongerbes.com/cool-stuff</p>
       </div>
     ),
     { ...size, debug: false }

--- a/app/cool-stuff/[id]/opengraph-image.tsx
+++ b/app/cool-stuff/[id]/opengraph-image.tsx
@@ -1,0 +1,54 @@
+import { ImageResponse } from 'next/server'
+import { getCoolThing } from '../utils'
+import clsx from 'clsx'
+
+// This doesn't seem to currently support dynamic values
+// export const alt = 'TODO'
+
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function og({ params }: { params: { id: string } }) {
+  const { title, logoImg } = getCoolThing(params.id)
+  const logoImgSrc = `https://jasongerbes.com${logoImg.src}` // need to hard-code the full URL
+
+  return new ImageResponse(
+    (
+      <div tw="flex flex-col items-center justify-center w-full h-full pt-24 pb-8 px-8 border bg-neutral-900">
+        <div
+          tw="absolute bg-teal-600 py-4 px-28 text-center text-3xl font-medium uppercase tracking-wider text-teal-900"
+          style={{
+            top: 70,
+            left: -90,
+            transform: 'rotate(-45deg)',
+          }}
+        >
+          Cool Stuff
+        </div>
+
+        <div
+          tw={clsx(
+            'flex items-center justify-center rounded-3xl border w-56 h-56',
+            logoImg.theme === 'light'
+              ? 'bg-white border-teal-900/20'
+              : 'bg-neutral-800 border-neutral-700/50'
+          )}
+        >
+          <img
+            src={logoImgSrc}
+            width={160}
+            height={160}
+            style={{ objectFit: 'contain' }}
+          />
+        </div>
+
+        <p tw="text-neutral-100 text-[85px] font-semibold max-w-full mt-8">
+          {title}
+        </p>
+
+        <p tw="text-neutral-400 text-[28px] mt-6">jasongerbes.com/cool-stuff</p>
+      </div>
+    ),
+    { ...size, debug: false }
+  )
+}

--- a/app/cool-stuff/[id]/page.tsx
+++ b/app/cool-stuff/[id]/page.tsx
@@ -1,32 +1,21 @@
 import { CoolThing, allCoolThings } from '@/.contentlayer/generated'
 import { Title } from '@/components/Title'
 import { Metadata } from 'next'
-import { notFound } from 'next/navigation'
 import { formatDate } from '@/utils/format-date'
 import { Mdx } from '@/components/Mdx'
 import { CoolThingIcon } from '@/components/CoolThingIcon'
 import { Prose } from '@/components/Prose'
 import { CustomLink } from '@/components/CustomLink'
-
-function getCoolThing(id: string[]): CoolThing {
-  const thingId = id.join('/')
-  const thing = allCoolThings.find((p) => p.id === thingId)
-
-  if (!thing || (process.env.NODE_ENV === 'production' && thing.isArchived)) {
-    notFound()
-  }
-
-  return thing
-}
+import { getCoolThing } from '../utils'
 
 interface Params {
-  id: string[]
+  id: string
 }
 
 export function generateStaticParams() {
   return allCoolThings
     .filter((thing) => !thing.isArchived)
-    .map((thing) => ({ id: thing.id.split('/') }))
+    .map((thing) => ({ id: thing.id }))
 }
 
 export function generateMetadata({ params }: { params: Params }): Metadata {

--- a/app/cool-stuff/opengraph-image.tsx
+++ b/app/cool-stuff/opengraph-image.tsx
@@ -1,0 +1,26 @@
+import { ImageResponse } from 'next/server'
+
+export const alt = 'About Acme'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function og() {
+  return new ImageResponse(
+    (
+      <div
+        tw="bg-gray-900 text-white"
+        style={{
+          fontSize: 128,
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        About Acme
+      </div>
+    ),
+    size
+  )
+}

--- a/app/cool-stuff/utils.ts
+++ b/app/cool-stuff/utils.ts
@@ -1,0 +1,12 @@
+import { CoolThing, allCoolThings } from '@/.contentlayer/generated'
+import { notFound } from 'next/navigation'
+
+export function getCoolThing(id: string): CoolThing {
+  const thing = allCoolThings.find((p) => p.id === id)
+
+  if (!thing || (process.env.NODE_ENV === 'production' && thing.isArchived)) {
+    notFound()
+  }
+
+  return thing
+}


### PR DESCRIPTION
Use the file-based metadata feature in Next to create dynamic `og:image` values for the cool stuff pages

https://beta.nextjs.org/docs/api-reference/metadata#generate-a-dynamic-image