### PR TITLE
Metadata images

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,7 @@
   },
   "overrides": [
     {
-      "files": ["**/opengraph-image.tsx"],
+      "files": ["components/metadata-images/**/*.tsx"],
       "rules": {
         "@next/next/no-img-element": "off",
         "jsx-a11y/alt-text": "off"

--- a/app/blog/[id]/opengraph-image.tsx
+++ b/app/blog/[id]/opengraph-image.tsx
@@ -1,0 +1,16 @@
+import { ImageResponse } from 'next/server'
+import { getBlogPost } from '../utils'
+import { BlogPostMetadataImage } from '@/components/metadata-images/BlogPostMetadataImage'
+
+export const alt = 'Blog - Jason Gerbes'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function ogImage({ params }: { params: { id: string } }) {
+  const post = getBlogPost(params.id)
+
+  return new ImageResponse(<BlogPostMetadataImage post={post} />, {
+    ...size,
+    debug: false,
+  })
+}

--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -1,29 +1,18 @@
 import { BlogPost, allBlogPosts } from '@/.contentlayer/generated'
 import { Title } from '@/components/Title'
 import { Metadata } from 'next'
-import { notFound } from 'next/navigation'
 import { formatDate } from '@/utils/format-date'
 import { Markdown } from '@/components/Markdown'
-
-function getBlogPost(id: string[]): BlogPost {
-  const postId = id.join('/')
-  const post = allBlogPosts.find((p) => p.id === postId)
-
-  if (!post || (process.env.NODE_ENV === 'production' && !post.isPublished)) {
-    notFound()
-  }
-
-  return post
-}
+import { getBlogPost } from '../utils'
 
 interface Params {
-  id: string[]
+  id: string
 }
 
 export function generateStaticParams() {
   return allBlogPosts
     .filter((post) => post.isPublished)
-    .map((post) => ({ id: post.id.split('/') }))
+    .map((post) => ({ id: post.id }))
 }
 
 export function generateMetadata({ params }: { params: Params }): Metadata {
@@ -43,6 +32,7 @@ export function generateMetadata({ params }: { params: Params }): Metadata {
     twitter: {
       title,
       description,
+      card: 'summary_large_image',
     },
   }
 }

--- a/app/blog/[id]/twitter-image.tsx
+++ b/app/blog/[id]/twitter-image.tsx
@@ -1,0 +1,16 @@
+import { ImageResponse } from 'next/server'
+import { getBlogPost } from '../utils'
+import { BlogPostMetadataImage } from '@/components/metadata-images/BlogPostMetadataImage'
+
+export const alt = 'Blog - Jason Gerbes'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function twitterImage({ params }: { params: { id: string } }) {
+  const post = getBlogPost(params.id)
+
+  return new ImageResponse(<BlogPostMetadataImage post={post} />, {
+    ...size,
+    debug: false,
+  })
+}

--- a/app/blog/utils.ts
+++ b/app/blog/utils.ts
@@ -1,0 +1,12 @@
+import { BlogPost, allBlogPosts } from '@/.contentlayer/generated'
+import { notFound } from 'next/navigation'
+
+export function getBlogPost(id: string): BlogPost {
+  const post = allBlogPosts.find((p) => p.id === id)
+
+  if (!post || (process.env.NODE_ENV === 'production' && !post.isPublished)) {
+    notFound()
+  }
+
+  return post
+}

--- a/app/cool-stuff/[id]/opengraph-image.tsx
+++ b/app/cool-stuff/[id]/opengraph-image.tsx
@@ -8,5 +8,8 @@ export const contentType = 'image/png'
 
 export default function ogImage({ params }: { params: { id: string } }) {
   const thing = getCoolThing(params.id)
-  return new ImageResponse(<CoolThingMetadataImage thing={thing} />, size)
+  return new ImageResponse(<CoolThingMetadataImage thing={thing} />, {
+    ...size,
+    debug: false,
+  })
 }

--- a/app/cool-stuff/[id]/opengraph-image.tsx
+++ b/app/cool-stuff/[id]/opengraph-image.tsx
@@ -8,6 +8,7 @@ export const contentType = 'image/png'
 
 export default function ogImage({ params }: { params: { id: string } }) {
   const thing = getCoolThing(params.id)
+
   return new ImageResponse(<CoolThingMetadataImage thing={thing} />, {
     ...size,
     debug: false,

--- a/app/cool-stuff/[id]/page.tsx
+++ b/app/cool-stuff/[id]/page.tsx
@@ -36,6 +36,7 @@ export function generateMetadata({ params }: { params: Params }): Metadata {
     twitter: {
       title,
       description,
+      card: 'summary_large_image',
     },
   }
 }

--- a/app/cool-stuff/[id]/twitter-image.tsx
+++ b/app/cool-stuff/[id]/twitter-image.tsx
@@ -6,7 +6,7 @@ export const alt = 'Cool Stuff - Jason Gerbes'
 export const size = { width: 1200, height: 630 }
 export const contentType = 'image/png'
 
-export default function ogImage({ params }: { params: { id: string } }) {
+export default function twitterImage({ params }: { params: { id: string } }) {
   const thing = getCoolThing(params.id)
   return new ImageResponse(<CoolThingMetadataImage thing={thing} />, size)
 }

--- a/app/cool-stuff/[id]/twitter-image.tsx
+++ b/app/cool-stuff/[id]/twitter-image.tsx
@@ -8,5 +8,9 @@ export const contentType = 'image/png'
 
 export default function twitterImage({ params }: { params: { id: string } }) {
   const thing = getCoolThing(params.id)
-  return new ImageResponse(<CoolThingMetadataImage thing={thing} />, size)
+
+  return new ImageResponse(<CoolThingMetadataImage thing={thing} />, {
+    ...size,
+    debug: false,
+  })
 }

--- a/components/CoolThingIcon.tsx
+++ b/components/CoolThingIcon.tsx
@@ -9,7 +9,7 @@ export interface CoolThingIconProps {
 }
 
 export function CoolThingIcon({ className, thing, size }: CoolThingIconProps) {
-  const { logoImg } = thing
+  const { logoImage } = thing
   const imgSize = size === 'normal' ? 36 : 80
 
   return (
@@ -17,9 +17,9 @@ export function CoolThingIcon({ className, thing, size }: CoolThingIconProps) {
       className={clsx(
         'flex items-center justify-center border border-primary-900/20 dark:border-gray-700/50',
         {
-          'bg-white dark:bg-gray-800': logoImg.theme === 'auto',
-          'bg-white dark:bg-gray-200': logoImg.theme === 'light',
-          'bg-gray-800': logoImg.theme === 'dark',
+          'bg-white dark:bg-gray-800': logoImage.theme === 'auto',
+          'bg-white dark:bg-gray-200': logoImage.theme === 'light',
+          'bg-gray-800': logoImage.theme === 'dark',
         },
         {
           'rounded-lg p-2': size === 'normal',
@@ -33,7 +33,7 @@ export function CoolThingIcon({ className, thing, size }: CoolThingIconProps) {
           'h-9 w-9': size === 'normal',
           'h-20 w-20': size === 'large',
         })}
-        src={logoImg.src}
+        src={logoImage.src}
         alt={`The logo image for ${thing.title}`}
         width={imgSize}
         height={imgSize}

--- a/components/metadata-images/BlogPostMetadataImage.tsx
+++ b/components/metadata-images/BlogPostMetadataImage.tsx
@@ -1,0 +1,7 @@
+import { BlogPost } from '@/.contentlayer/generated'
+import { MetadataImage } from './MetadataImage'
+
+export function BlogPostMetadataImage({ post }: { post: BlogPost }) {
+  const { title } = post
+  return <MetadataImage title={title} pathname="/blog" />
+}

--- a/components/metadata-images/CoolThingMetadataImage.tsx
+++ b/components/metadata-images/CoolThingMetadataImage.tsx
@@ -11,10 +11,11 @@ export function CoolThingMetadataImage({ thing }: { thing: CoolThing }) {
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'space-between',
-        padding: '96px 96px 0',
+        padding: '90px 80px 45px',
         width: '100%',
         height: '100%',
-        backgroundColor: '#171717',
+        background:
+          'linear-gradient(150deg, rgba(10,10,10,1) 0%, rgba(23,23,23,1) 43%, rgba(38,38,38,1) 100%)',
       }}
     >
       <div
@@ -36,7 +37,14 @@ export function CoolThingMetadataImage({ thing }: { thing: CoolThing }) {
         Cool Stuff
       </div>
 
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          flexGrow: 1,
+          justifyContent: 'center',
+        }}
+      >
         <div
           style={{
             display: 'flex',
@@ -62,8 +70,8 @@ export function CoolThingMetadataImage({ thing }: { thing: CoolThing }) {
         <p
           style={{
             fontSize: 75,
-            lineHeight: 1.1,
-            marginTop: 32,
+            lineHeight: 1.025,
+            marginTop: 42,
             fontWeight: 400,
             color: '#f5f5f5',
             maxWidth: '80%',
@@ -73,31 +81,29 @@ export function CoolThingMetadataImage({ thing }: { thing: CoolThing }) {
         </p>
       </div>
 
-      <div
+      <p
         style={{
-          display: 'flex',
-          justifyContent: 'flex-end',
-          alignItems: 'flex-start',
-          marginRight: -60,
+          fontSize: 22,
+          color: '#a3a3a3',
+          textTransform: 'uppercase',
+          letterSpacing: '0.1em',
         }}
       >
-        <p
-          style={{
-            fontSize: 24,
-            color: '#a3a3a3',
-            textTransform: 'uppercase',
-            letterSpacing: '0.1em',
-          }}
-        >
-          jasongerbes.com/cool-stuff
-        </p>
-        <img
-          src={siteLogoImageSrc}
-          width={90}
-          height={90}
-          style={{ objectFit: 'contain', marginLeft: 24 }}
-        />
-      </div>
+        jasongerbes.com/cool-stuff
+      </p>
+
+      <img
+        src={siteLogoImageSrc}
+        width={160}
+        height={160}
+        style={{
+          objectFit: 'contain',
+          marginLeft: 24,
+          position: 'absolute',
+          bottom: 0,
+          right: 45,
+        }}
+      />
     </div>
   )
 }

--- a/components/metadata-images/CoolThingMetadataImage.tsx
+++ b/components/metadata-images/CoolThingMetadataImage.tsx
@@ -47,14 +47,14 @@ export function CoolThingMetadataImage({ thing }: { thing: CoolThing }) {
             borderColor: logoImg.theme === 'light' ? '#929292' : '#333333',
             borderRadius: 24,
             backgroundColor: logoImg.theme === 'light' ? 'white' : '#262626',
-            width: 170,
-            height: 170,
+            width: 160,
+            height: 160,
           }}
         >
           <img
             src={logoImgSrc}
-            width={120}
-            height={120}
+            width={110}
+            height={110}
             style={{ objectFit: 'contain' }}
           />
         </div>
@@ -77,7 +77,7 @@ export function CoolThingMetadataImage({ thing }: { thing: CoolThing }) {
         style={{
           display: 'flex',
           justifyContent: 'flex-end',
-          alignItems: 'center',
+          alignItems: 'flex-start',
           marginRight: -60,
         }}
       >
@@ -95,7 +95,7 @@ export function CoolThingMetadataImage({ thing }: { thing: CoolThing }) {
           src={siteLogoImageSrc}
           width={90}
           height={90}
-          style={{ objectFit: 'contain', marginLeft: 16 }}
+          style={{ objectFit: 'contain', marginLeft: 24 }}
         />
       </div>
     </div>

--- a/components/metadata-images/CoolThingMetadataImage.tsx
+++ b/components/metadata-images/CoolThingMetadataImage.tsx
@@ -1,0 +1,103 @@
+import { CoolThing } from '@/.contentlayer/generated'
+
+export function CoolThingMetadataImage({ thing }: { thing: CoolThing }) {
+  const { title, logoImg } = thing
+  const logoImgSrc = `https://jasongerbes.com${logoImg.src}` // need to hard-code the full URL
+  const siteLogoImageSrc = 'https://jasongerbes.com/images/site-logo.png'
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '96px 96px 0',
+        width: '100%',
+        height: '100%',
+        backgroundColor: '#171717',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: 60,
+          right: -90,
+          transform: 'rotate(45deg)',
+          backgroundColor: '#0f766e',
+          color: '#042f2e',
+          textAlign: 'center',
+          fontSize: 30,
+          fontWeight: 500,
+          textTransform: 'uppercase',
+          padding: '24px 112px',
+          letterSpacing: '0.05em',
+        }}
+      >
+        Cool Stuff
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderStyle: 'solid',
+            borderWidth: 1,
+            borderColor: logoImg.theme === 'light' ? '#929292' : '#333333',
+            borderRadius: 24,
+            backgroundColor: logoImg.theme === 'light' ? 'white' : '#262626',
+            width: 170,
+            height: 170,
+          }}
+        >
+          <img
+            src={logoImgSrc}
+            width={120}
+            height={120}
+            style={{ objectFit: 'contain' }}
+          />
+        </div>
+
+        <p
+          style={{
+            fontSize: 75,
+            lineHeight: 1.1,
+            marginTop: 32,
+            fontWeight: 400,
+            color: '#f5f5f5',
+            maxWidth: '80%',
+          }}
+        >
+          {title}
+        </p>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+          marginRight: -60,
+        }}
+      >
+        <p
+          style={{
+            fontSize: 24,
+            color: '#a3a3a3',
+            textTransform: 'uppercase',
+            letterSpacing: '0.1em',
+          }}
+        >
+          jasongerbes.com/cool-stuff
+        </p>
+        <img
+          src={siteLogoImageSrc}
+          width={90}
+          height={90}
+          style={{ objectFit: 'contain', marginLeft: 16 }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/components/metadata-images/CoolThingMetadataImage.tsx
+++ b/components/metadata-images/CoolThingMetadataImage.tsx
@@ -1,109 +1,15 @@
 import { CoolThing } from '@/.contentlayer/generated'
+import { MetadataImage } from './MetadataImage'
 
 export function CoolThingMetadataImage({ thing }: { thing: CoolThing }) {
-  const { title, logoImg } = thing
-  const logoImgSrc = `https://jasongerbes.com${logoImg.src}` // need to hard-code the full URL
-  const siteLogoImageSrc = 'https://jasongerbes.com/images/site-logo.png'
+  const { title, logoImage } = thing
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'space-between',
-        padding: '90px 80px 45px',
-        width: '100%',
-        height: '100%',
-        background:
-          'linear-gradient(150deg, rgba(10,10,10,1) 0%, rgba(23,23,23,1) 43%, rgba(38,38,38,1) 100%)',
-      }}
-    >
-      <div
-        style={{
-          position: 'absolute',
-          top: 60,
-          right: -90,
-          transform: 'rotate(45deg)',
-          backgroundColor: '#0f766e',
-          color: '#042f2e',
-          textAlign: 'center',
-          fontSize: 30,
-          fontWeight: 500,
-          textTransform: 'uppercase',
-          padding: '24px 112px',
-          letterSpacing: '0.05em',
-        }}
-      >
-        Cool Stuff
-      </div>
-
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          flexGrow: 1,
-          justifyContent: 'center',
-        }}
-      >
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            borderStyle: 'solid',
-            borderWidth: 1,
-            borderColor: logoImg.theme === 'light' ? '#929292' : '#333333',
-            borderRadius: 24,
-            backgroundColor: logoImg.theme === 'light' ? 'white' : '#262626',
-            width: 160,
-            height: 160,
-          }}
-        >
-          <img
-            src={logoImgSrc}
-            width={110}
-            height={110}
-            style={{ objectFit: 'contain' }}
-          />
-        </div>
-
-        <p
-          style={{
-            fontSize: 75,
-            lineHeight: 1.025,
-            marginTop: 42,
-            fontWeight: 400,
-            color: '#f5f5f5',
-            maxWidth: '80%',
-          }}
-        >
-          {title}
-        </p>
-      </div>
-
-      <p
-        style={{
-          fontSize: 22,
-          color: '#a3a3a3',
-          textTransform: 'uppercase',
-          letterSpacing: '0.1em',
-        }}
-      >
-        jasongerbes.com/cool-stuff
-      </p>
-
-      <img
-        src={siteLogoImageSrc}
-        width={160}
-        height={160}
-        style={{
-          objectFit: 'contain',
-          marginLeft: 24,
-          position: 'absolute',
-          bottom: 0,
-          right: 45,
-        }}
-      />
-    </div>
+    <MetadataImage
+      title={title}
+      logoImage={logoImage}
+      bannerText="Cool Stuff"
+      pathname="/cool-stuff"
+    />
   )
 }

--- a/components/metadata-images/MetadataImage.tsx
+++ b/components/metadata-images/MetadataImage.tsx
@@ -1,0 +1,130 @@
+import { Image } from '@/.contentlayer/generated'
+
+export interface MetadataImage {
+  title: string
+  pathname?: string
+  logoImage?: Image
+  bannerText?: string
+}
+
+export function MetadataImage({
+  title,
+  pathname,
+  logoImage,
+  bannerText,
+}: MetadataImage) {
+  const siteLogoImageSrc = 'https://jasongerbes.com/images/site-logo.png'
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '90px 80px 45px',
+        width: '100%',
+        height: '100%',
+        background:
+          'linear-gradient(150deg, rgba(10,10,10,1) 0%, rgba(23,23,23,1) 43%, rgba(38,38,38,1) 100%)',
+      }}
+    >
+      {bannerText && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 60,
+            right: -90,
+            transform: 'rotate(45deg)',
+            backgroundColor: '#0f766e',
+            color: '#042f2e',
+            textAlign: 'center',
+            fontSize: 30,
+            fontWeight: 500,
+            textTransform: 'uppercase',
+            padding: '24px 112px',
+            letterSpacing: '0.05em',
+          }}
+        >
+          {bannerText}
+        </div>
+      )}
+
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          flexGrow: 1,
+          justifyContent: 'center',
+        }}
+      >
+        {logoImage && <MetadataLogoImage image={logoImage} />}
+
+        <p
+          style={{
+            fontSize: 75,
+            lineHeight: 1.025,
+            marginTop: 42,
+            fontWeight: 400,
+            color: '#f5f5f5',
+            maxWidth: '80%',
+          }}
+        >
+          {title}
+        </p>
+      </div>
+
+      <p
+        style={{
+          fontSize: 22,
+          color: '#a3a3a3',
+          textTransform: 'uppercase',
+          letterSpacing: '0.1em',
+          paddingTop: 24,
+        }}
+      >
+        jasongerbes.com{pathname}
+      </p>
+
+      <img
+        src={siteLogoImageSrc}
+        width={160}
+        height={160}
+        style={{
+          objectFit: 'contain',
+          marginLeft: 24,
+          position: 'absolute',
+          bottom: 0,
+          right: 45,
+        }}
+      />
+    </div>
+  )
+}
+
+function MetadataLogoImage({ image }: { image: Image }) {
+  const imageSrc = `https://jasongerbes.com${image.src}`
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderStyle: 'solid',
+        borderWidth: 1,
+        borderColor: image.theme === 'light' ? '#929292' : '#333333',
+        borderRadius: 24,
+        backgroundColor: image.theme === 'light' ? 'white' : '#262626',
+        width: 160,
+        height: 160,
+      }}
+    >
+      <img
+        src={imageSrc}
+        width={110}
+        height={110}
+        style={{ objectFit: 'contain' }}
+      />
+    </div>
+  )
+}

--- a/content/cool-things/bundlephobia.mdx
+++ b/content/cool-things/bundlephobia.mdx
@@ -1,7 +1,7 @@
 ---
 title: bundlephobia
 description: Find the cost of adding a npm package to your bundle.
-logoImg:
+logoImage:
   src: /images/logos/bundlephobia.svg
 websiteUrl: https://bundlephobia.com
 categories:

--- a/content/cool-things/chatgpt.mdx
+++ b/content/cool-things/chatgpt.mdx
@@ -1,7 +1,7 @@
 ---
 title: ChatGPT
 description: No introduction needed. ChatGPT has set new expectations for what generative AI can do.
-logoImg:
+logoImage:
   src: /images/logos/chatgpt.svg
 websiteUrl: https://chat.openai.com
 categories:

--- a/content/cool-things/cloudflare-turnstile.mdx
+++ b/content/cool-things/cloudflare-turnstile.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cloudflare Turnstile
 description: A friendly, privacy-focused, free CAPTCHA replacement.
-logoImg:
+logoImage:
   src: /images/logos/cloudflare.svg
 websiteUrl: https://cloudflare.com/products/turnstile
 categories:

--- a/content/cool-things/clsx.mdx
+++ b/content/cool-things/clsx.mdx
@@ -1,7 +1,7 @@
 ---
 title: clsx
 description: A tiny (228B) utility for constructing className strings conditionally.
-logoImg:
+logoImage:
   src: /images/logos/npm.svg
 websiteUrl: https://npmjs.com/package/clsx
 categories:

--- a/content/cool-things/concurrently.mdx
+++ b/content/cool-things/concurrently.mdx
@@ -1,7 +1,7 @@
 ---
 title: concurrently
 description: Run multiple commands concurrently. Like `npm run watch-js & npm run watch-less`, but better.
-logoImg:
+logoImage:
   src: /images/logos/npm.svg
 websiteUrl: https://npmjs.com/package/concurrently
 categories:

--- a/content/cool-things/contentlayer.mdx
+++ b/content/cool-things/contentlayer.mdx
@@ -1,7 +1,7 @@
 ---
 title: Contentlayer
 description: Automatically convert your MDX content into type-safe data for your Next.js app.
-logoImg:
+logoImage:
   src: /images/logos/contentlayer.svg
 websiteUrl: https://www.contentlayer.dev
 categories:

--- a/content/cool-things/cva.mdx
+++ b/content/cool-things/cva.mdx
@@ -1,7 +1,7 @@
 ---
 title: cva
 description: Class Variance Authority - a painless way to create class string variations based on props.
-logoImg:
+logoImage:
   src: /images/logos/cva.svg
   theme: dark
 websiteUrl: https://cva.style

--- a/content/cool-things/framer-motion.mdx
+++ b/content/cool-things/framer-motion.mdx
@@ -1,7 +1,7 @@
 ---
 title: Framer Motion
 description: A production-ready motion library for React, made by the incredible Matt Perry at Framer.
-logoImg:
+logoImage:
   src: /images/logos/framer.svg
   theme: dark
 websiteUrl: https://framer.com/motion

--- a/content/cool-things/headless-ui.mdx
+++ b/content/cool-things/headless-ui.mdx
@@ -1,7 +1,7 @@
 ---
 title: Headless UI
 description: Completely unstyled, fully accessible UI components, designed to integrate beautifully with Tailwind CSS.
-logoImg:
+logoImage:
   src: /images/logos/headless-ui.svg
 websiteUrl: https://headlessui.com
 categories:

--- a/content/cool-things/motion-one.mdx
+++ b/content/cool-things/motion-one.mdx
@@ -1,7 +1,7 @@
 ---
 title: Motion One
 description: The smallest fully-featured animation library for the web, another hit from Matt Perry.
-logoImg:
+logoImage:
   src: /images/logos/motion-one.svg
   theme: light
 websiteUrl: https://motion.dev

--- a/content/cool-things/nextjs.mdx
+++ b/content/cool-things/nextjs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Next.js
 description: Turbocharge your React applications with the most deeply-integrated web framework.
-logoImg:
+logoImage:
   src: /images/logos/nextjs.svg
   theme: light
 websiteUrl: https://nextjs.org

--- a/content/cool-things/nivo.mdx
+++ b/content/cool-things/nivo.mdx
@@ -1,7 +1,7 @@
 ---
 title: nivo
 description: A rich set of dataviz components (interactive charts), built on top of D3 and React.
-logoImg:
+logoImage:
   src: /images/logos/nivo.png
   theme: light
 websiteUrl: https://nivo.rocks

--- a/content/cool-things/npm-trends.mdx
+++ b/content/cool-things/npm-trends.mdx
@@ -1,7 +1,7 @@
 ---
 title: npm trends
 description: Compare packages download stats, bundle sizes, GitHub stars, and more. Spot trends and pick the winner.
-logoImg:
+logoImage:
   src: /images/logos/npm-trends.png
 websiteUrl: https://npmtrends.com
 categories:

--- a/content/cool-things/patch-package.mdx
+++ b/content/cool-things/patch-package.mdx
@@ -1,7 +1,7 @@
 ---
 title: patch-package
 description: Instantly make and keep fixes to npm dependencies.
-logoImg:
+logoImage:
   src: /images/logos/npm.svg
 websiteUrl: https://npmjs.com/package/patch-package
 categories:

--- a/content/cool-things/pretty-typescript-errors.mdx
+++ b/content/cool-things/pretty-typescript-errors.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pretty TypeScript Errors
 description: Make TypeScript errors prettier and more human-readable in VS Code.
-logoImg:
+logoImage:
   src: /images/logos/pretty-typescript-errors.png
 websiteUrl: https://marketplace.visualstudio.com/items?itemName=yoavbls.pretty-ts-errors
 categories:

--- a/content/cool-things/radix-ui.mdx
+++ b/content/cool-things/radix-ui.mdx
@@ -1,7 +1,7 @@
 ---
 title: Radix UI
 description: Unstyled, accessible components for building high‑quality design systems and web apps in React.
-logoImg:
+logoImage:
   src: /images/logos/radix-ui.svg
   theme: light
 websiteUrl: https://radix-ui.com

--- a/content/cool-things/react-aria.mdx
+++ b/content/cool-things/react-aria.mdx
@@ -1,7 +1,7 @@
 ---
 title: React Aria
 description: A library of React Hooks that provides accessible UI primitives for your design system.
-logoImg:
+logoImage:
   src: /images/logos/react-aria.svg
   theme: light
 websiteUrl: https://react-spectrum.adobe.com/react-aria

--- a/content/cool-things/react-wrap-balancer.mdx
+++ b/content/cool-things/react-wrap-balancer.mdx
@@ -1,7 +1,7 @@
 ---
 title: React Wrap Balancer
 description: 'Makes titles more readable. Like CSS `text-wrap: balance`, but with browser support.'
-logoImg:
+logoImage:
   src: /images/logos/react-wrap-balancer.png
   theme: light
 websiteUrl: https://react-wrap-balancer.vercel.app

--- a/content/cool-things/storybook.mdx
+++ b/content/cool-things/storybook.mdx
@@ -1,7 +1,7 @@
 ---
 title: Storybook
 description: A frontend workshop for building UI components and pages in isolation.
-logoImg:
+logoImage:
   src: /images/logos/storybook.svg
 websiteUrl: https://storybook.js.org
 categories:

--- a/content/cool-things/tailwind-css.mdx
+++ b/content/cool-things/tailwind-css.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tailwind CSS
 description: The quickest and easiest way to write maintainable CSS with tiny file sizes.
-logoImg:
+logoImage:
   src: /images/logos/tailwind-css.svg
 websiteUrl: https://tailwindcss.com
 categories:

--- a/content/cool-things/trpc.mdx
+++ b/content/cool-things/trpc.mdx
@@ -1,7 +1,7 @@
 ---
 title: tRPC
 description: Move Fast and Break Nothing. End-to-end typesafe APIs made easy.
-logoImg:
+logoImage:
   src: /images/logos/trpc.svg
 websiteUrl: https://trpc.io
 categories:

--- a/content/cool-things/use-gesture.mdx
+++ b/content/cool-things/use-gesture.mdx
@@ -1,7 +1,7 @@
 ---
 title: '@use-gesture'
 description: Bind richer mouse and touch events to any component or view.
-logoImg:
+logoImage:
   src: /images/logos/use-gesture.png
 websiteUrl: https://use-gesture.netlify.app
 categories:

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -86,7 +86,7 @@ export const CoolThing = defineDocumentType(() => ({
       description: 'A description of the thing',
       required: true,
     },
-    logoImg: {
+    logoImage: {
       type: 'nested',
       description: 'The logo image for the thing',
       required: true,


### PR DESCRIPTION
- Add generic `<MetadataImage>` component
- Add `twitter-image.tsx` for cool stuff and tweak design
- Add metadata images for blog posts
- Rename `logoImg` to `logoImage`

![opengraph-image-6](https://user-images.githubusercontent.com/13686180/233559528-19796c6e-1a5d-473d-8743-b438d80068ce.png)

![opengraph-image-7](https://user-images.githubusercontent.com/13686180/233559667-7a6ef528-02ba-49f9-be6c-7bcba2857087.png)
