### PR TITLE
Address Lighthouse accessibility issues

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -27,7 +27,7 @@ export function Footer() {
   const year = new Date().getFullYear()
 
   return (
-    <footer className="border-t border-primary-600/10 bg-primary-50/70 px-8 pb-16 pt-16 dark:border-primary-900/30 dark:bg-primary-900/20 sm:px-8 lg:border-none lg:bg-transparent lg:pt-0">
+    <footer className="border-t border-primary-600/10 bg-primary-50/50 px-8 pb-16 pt-16 dark:border-primary-900/30 dark:bg-primary-900/20 sm:px-8 lg:border-none lg:bg-transparent lg:pt-0">
       <div className="mx-auto flex max-w-7xl flex-col justify-between gap-16 sm:items-center lg:justify-center">
         <nav className="lg:hidden">
           <ul className="flex flex-col gap-6 text-base font-semibold sm:flex-row sm:gap-8">
@@ -36,7 +36,7 @@ export function Footer() {
             ))}
           </ul>
         </nav>
-        <p className="text-center text-sm text-primary-700/70 lg:text-gray-500 dark:lg:text-gray-400">
+        <p className="text-center text-sm text-primary-800 dark:text-primary-500 lg:text-gray-500 dark:lg:text-gray-400">
           &copy; {year} Jason Gerbes. All rights reserved.
         </p>
       </div>
@@ -53,7 +53,7 @@ function FooterNavLink({ href, label }: FooterNavLinkProps) {
   return (
     <li>
       <Link
-        className="text-primary-800 transition-colors hover:text-primary-600 dark:text-primary-600 dark:hover:text-primary-700"
+        className="text-primary-800 transition-colors hover:text-primary-600 dark:text-primary-500 dark:hover:text-primary-700"
         href={href}
       >
         {label}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -50,6 +50,7 @@ export function Header() {
           className="lg:dark:border-primary-900/300 hidden text-center xs:block lg:w-full lg:border-b-2 lg:border-primary-600/10"
           href="/"
           aria-hidden="true"
+          tabIndex={-1}
         >
           <Image
             className="mx-auto h-12 w-12 lg:h-28 lg:w-28"

--- a/components/Prose.tsx
+++ b/components/Prose.tsx
@@ -14,6 +14,7 @@ export function Prose({ className, children }: ProseProps) {
         'prose-a:font-semibold prose-a:text-primary-800 prose-a:underline-offset-2 prose-a:transition-colors hover:prose-a:text-primary-600 dark:prose-a:text-primary-500 dark:hover:prose-a:text-primary-700',
         'prose-p:text-gray-700 dark:prose-p:text-gray-300',
         'prose-th:font-semibold',
+        'prose-pre:bg-gray-900',
         className
       )}
     >

--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -11,7 +11,7 @@ export function Tag({ className, icon: Icon, children }: TagProps) {
   return (
     <div
       className={clsx(
-        'inline-flex items-center gap-1 rounded-md bg-gray-300/20 px-2 py-1.5 text-sm font-medium text-gray-500 dark:bg-gray-700/30 dark:text-gray-400',
+        'inline-flex items-center gap-1 rounded-md bg-gray-200/30 px-2 py-1.5 text-sm font-medium text-gray-600 dark:bg-gray-700/30 dark:text-gray-400',
         className
       )}
     >

--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -3,17 +3,25 @@ import clsx from 'clsx'
 
 export interface TagProps {
   className?: string
+  accessibleLabel: string
   icon?: React.ComponentType<IconProps>
   children: React.ReactNode
 }
 
-export function Tag({ className, icon: Icon, children }: TagProps) {
+export function Tag({
+  className,
+  accessibleLabel,
+  icon: Icon,
+  children,
+}: TagProps) {
   return (
     <div
       className={clsx(
         'inline-flex items-center gap-1 rounded-md bg-gray-200/30 px-2 py-1.5 text-sm font-medium text-gray-600 dark:bg-gray-700/30 dark:text-gray-400',
         className
       )}
+      title={accessibleLabel}
+      aria-label={accessibleLabel}
     >
       {Icon && <Icon weight="bold" aria-hidden="true" />}
       <span>{children}</span>

--- a/components/blog-posts/BlogPostTags.tsx
+++ b/components/blog-posts/BlogPostTags.tsx
@@ -10,13 +10,25 @@ export interface BlogPostTagsProps {
 }
 
 export function BlogPostTags({ className, post }: BlogPostTagsProps) {
+  const publishDate = formatDate(post.publishDate)
+
   return (
     <div className={clsx('flex flex-wrap gap-2', className)}>
-      <Tag icon={CalendarBlank}>
-        <time dateTime={post.publishDate}>{formatDate(post.publishDate)}</time>
+      <Tag
+        accessibleLabel={`This post was published on ${publishDate}`}
+        icon={CalendarBlank}
+      >
+        <time dateTime={post.publishDate}>{publishDate}</time>
       </Tag>
 
-      <Tag icon={ClockCountdown}>{post.readingTime.text}</Tag>
+      <Tag
+        accessibleLabel={`This post takes about ${Math.floor(
+          post.readingTime.minutes
+        )} minutes to read`}
+        icon={ClockCountdown}
+      >
+        {post.readingTime.text}
+      </Tag>
     </div>
   )
 }

--- a/content/blog-posts/why-choose-tailwind-css.mdx
+++ b/content/blog-posts/why-choose-tailwind-css.mdx
@@ -26,22 +26,22 @@ Tailwind CSS styles are applied directly to elements by combining relevant class
 
 ```html
 <div class="grid grid-cols-1 gap-4 font-bold md:grid-cols-2 lg:grid-cols-3">
-  <div class="rounded bg-red-500 p-4 text-red-100 dark:bg-red-700/70 dark:text-red-200">Column 1</div>
-  <div class="rounded bg-orange-500 p-4 text-orange-100 dark:bg-orange-700/70 dark:text-orange-200">Column 2</div>
-  <div class="rounded bg-yellow-500 p-4 text-yellow-100 dark:bg-yellow-700/70 dark:text-yellow-200">Column 3</div>
-  <div class="rounded bg-green-500 p-4 text-green-100 dark:bg-green-700/70 dark:text-green-200">Column 4</div>
-  <div class="rounded bg-blue-500 p-4 text-blue-100 dark:bg-blue-700/70 dark:text-blue-200">Column 5</div>
-  <div class="rounded bg-purple-500 p-4 text-purple-100 dark:bg-purple-700/70 dark:text-purple-200">Column 6</div>
+  <div class="rounded bg-red-100 p-4 text-red-700 dark:bg-red-800/50 dark:text-red-100">Column 1</div>
+  <div class="rounded bg-orange-100 p-4 text-orange-700 dark:bg-orange-800/50 dark:text-orange-100">Column 2</div>
+  <div class="rounded bg-yellow-100 p-4 text-yellow-700 dark:bg-yellow-800/50 dark:text-yellow-100">Column 3</div>
+  <div class="rounded bg-green-100 p-4 text-green-700 dark:bg-green-800/50 dark:text-green-100">Column 4</div>
+  <div class="rounded bg-blue-100 p-4 text-blue-700 dark:bg-blue-800/50 dark:text-blue-100">Column 5</div>
+  <div class="rounded bg-purple-100 p-4 text-purple-700 dark:bg-purple-800/50 dark:text-purple-100">Column 6</div>
 </div>
 ```
 
 <div className="grid grid-cols-1 gap-4 font-bold md:grid-cols-2 lg:grid-cols-3">
-  <div className="rounded bg-red-500 p-4 text-red-100 dark:bg-red-700/70 dark:text-red-200">Column 1</div>
-  <div className="rounded bg-orange-500 p-4 text-orange-100 dark:bg-orange-700/70 dark:text-orange-200">Column 2</div>
-  <div className="rounded bg-yellow-500 p-4 text-yellow-100 dark:bg-yellow-700/70 dark:text-yellow-200">Column 3</div>
-  <div className="rounded bg-green-500 p-4 text-green-100 dark:bg-green-700/70 dark:text-green-200">Column 4</div>
-  <div className="rounded bg-blue-500 p-4 text-blue-100 dark:bg-blue-700/70 dark:text-blue-200">Column 5</div>
-  <div className="rounded bg-purple-500 p-4 text-purple-100 dark:bg-purple-700/70 dark:text-purple-200">Column 6</div>
+  <div className="rounded bg-red-100 p-4 text-red-700 dark:bg-red-800/50 dark:text-red-100">Column 1</div>
+  <div className="rounded bg-orange-100 p-4 text-orange-700 dark:bg-orange-800/50 dark:text-orange-100">Column 2</div>
+  <div className="rounded bg-yellow-100 p-4 text-yellow-700 dark:bg-yellow-800/50 dark:text-yellow-100">Column 3</div>
+  <div className="rounded bg-green-100 p-4 text-green-700 dark:bg-green-800/50 dark:text-green-100">Column 4</div>
+  <div className="rounded bg-blue-100 p-4 text-blue-700 dark:bg-blue-800/50 dark:text-blue-100">Column 5</div>
+  <div className="rounded bg-purple-100 p-4 text-purple-700 dark:bg-purple-800/50 dark:text-purple-100">Column 6</div>
 </div>
 
 This example showcases several features offered by Tailwind CSS:
@@ -82,22 +82,21 @@ Sure, this markup _seems_ like it should be better because every element has a '
 {/* other breakpoints here */}
 
 .grid__item {
-  color: white;
   padding: 1rem;
   border-radius: 0.25rem;
 }
 
 .grid__item--red {
-  background-color: rgb(239, 68, 68);
-  color: rgb(254, 226, 226);
+  background-color: rgb(254 226 226);
+  color: rgb(185 28 28);
 }
 
 {/* other colours here */}
 
 @media (prefers-color-scheme: dark) {
   .grid__item--red {
-    background-color: rgba(185, 28, 28, 0.7);
-    color: rgb(254, 202, 202);
+    background-color: rgb(153 27 27 / 0.5);
+    color: rgb(254 226 226);
   }
 
   {/* other colours here */}


### PR DESCRIPTION
- Improve `<Tag>` colour contrast.
- Improve mobile footer colour contrast.
- Improve prose code block colour contrast.
- Remove redundant home link from keyboard navigation.
- Improve tailwind example colour contrast.