### PR TITLE
Fix cool stuff filtering

### DIFF
--- a/components/cool-things/CoolThingListCategoryFilter.tsx
+++ b/components/cool-things/CoolThingListCategoryFilter.tsx
@@ -1,10 +1,11 @@
 import { cva } from 'class-variance-authority'
 import { HorizontalScrollContainer } from '../HorizontalScrollContainer'
+import { CoolThingCategory } from './filter-utils'
 
 export interface CoolThingListCategoryFilterProps {
-  categories: string[]
-  value: string | undefined
-  onChange: (value: string | undefined) => void
+  categories: CoolThingCategory[]
+  value: CoolThingCategory | undefined
+  onChange: (value: CoolThingCategory | undefined) => void
 }
 
 export function CoolThingListCategoryFilter({
@@ -12,7 +13,10 @@ export function CoolThingListCategoryFilter({
   value,
   onChange,
 }: CoolThingListCategoryFilterProps) {
-  const handleChange = (category: string | undefined, checked: boolean) => {
+  const handleChange = (
+    category: CoolThingCategory | undefined,
+    checked: boolean
+  ) => {
     if (checked) onChange(category)
   }
 
@@ -44,9 +48,9 @@ export function CoolThingListCategoryFilter({
 
 interface CategoryFilterOptionProps {
   label: string
-  value: string | undefined
+  value: CoolThingCategory | undefined
   checked: boolean
-  onChange: (value: string | undefined, checked: boolean) => void
+  onChange: (value: CoolThingCategory | undefined, checked: boolean) => void
 }
 
 const option = cva(

--- a/components/cool-things/CoolThingListFilter.tsx
+++ b/components/cool-things/CoolThingListFilter.tsx
@@ -1,9 +1,9 @@
 import { CoolThingListCategoryFilter } from './CoolThingListCategoryFilter'
 import { SearchInput } from '../SearchInput'
-import { CoolThingFilterValue } from './filter-utils'
+import { CoolThingCategory, CoolThingFilterValue } from './filter-utils'
 
 export interface CoolThingListFilterProps {
-  categories: string[]
+  categories: CoolThingCategory[]
   value: CoolThingFilterValue
   onChange: (search: CoolThingFilterValue) => void
 }

--- a/components/cool-things/filter-utils.ts
+++ b/components/cool-things/filter-utils.ts
@@ -30,6 +30,9 @@ export function getFilteredCoolThings(
 ): CoolThing[] {
   const filters: CoolThingFilter[] = []
 
+  // filter out archived things
+  filters.push((thing) => !thing.isArchived)
+
   // filter based on the selected category
   if (category) {
     filters.push((thing) => thing.categories.includes(category))
@@ -55,22 +58,20 @@ function sortThingsDescending(
   things: CoolThing[],
   limit?: number
 ): CoolThing[] {
-  const sortedThings = things
-    .filter((thing) => !thing.isArchived)
-    .sort((a, b) => {
-      if (a.coolFactor !== b.coolFactor) {
-        return b.coolFactor - a.coolFactor
-      }
+  const sortedThings = things.sort((a, b) => {
+    if (a.coolFactor !== b.coolFactor) {
+      return b.coolFactor - a.coolFactor
+    }
 
-      const dateA = new Date(a.addedDate).getTime()
-      const dateB = new Date(b.addedDate).getTime()
+    const dateA = new Date(a.addedDate).getTime()
+    const dateB = new Date(b.addedDate).getTime()
 
-      if (dateA !== dateB) {
-        return dateB - dateA
-      }
+    if (dateA !== dateB) {
+      return dateB - dateA
+    }
 
-      return a.title.localeCompare(b.title)
-    })
+    return a.title.localeCompare(b.title)
+  })
 
   return limit ? sortedThings.slice(0, limit) : sortedThings
 }

--- a/components/cool-things/filter-utils.ts
+++ b/components/cool-things/filter-utils.ts
@@ -5,14 +5,16 @@ export function getCoolThingCategories(things: CoolThing[]) {
   const categorySet = things.reduce((acc, thing) => {
     thing.categories.forEach((category) => acc.add(category))
     return acc
-  }, new Set<string>())
+  }, new Set<CoolThingCategory>())
 
   return Array.from(categorySet)
 }
 
+export type CoolThingCategory = CoolThing['categories'][number]
+
 export interface CoolThingFilterValue {
   searchQuery: string
-  category: string | undefined
+  category: CoolThingCategory | undefined
 }
 
 export const defaultCoolThingFilterValue: CoolThingFilterValue = {
@@ -20,35 +22,33 @@ export const defaultCoolThingFilterValue: CoolThingFilterValue = {
   category: undefined,
 }
 
+type CoolThingFilter = (thing: CoolThing) => boolean
+
 export function getFilteredCoolThings(
   things: CoolThing[],
-  filter: CoolThingFilterValue
+  { searchQuery, category }: CoolThingFilterValue
 ): CoolThing[] {
-  const expressions: Fuse.Expression[] = []
-
-  // fuzzy match the search query to the title or description of the things
-  if (filter.searchQuery !== '') {
-    expressions.push({
-      $or: [{ title: filter.searchQuery }, { description: filter.searchQuery }],
-    })
-  }
+  const filters: CoolThingFilter[] = []
 
   // filter based on the selected category
-  if (filter.category) {
-    expressions.push({ categories: `'${filter.category}` })
+  if (category) {
+    filters.push((thing) => thing.categories.includes(category))
   }
 
-  // no need to search, return all things
-  if (expressions.length === 0) {
-    return sortThingsDescending(things)
+  // apply all filters
+  const filteredThings = things.filter((thing) =>
+    filters.every((filter) => filter(thing))
+  )
+
+  // no need to search, return filteredThings
+  if (searchQuery === '') {
+    return sortThingsDescending(filteredThings)
   }
 
-  const fuse = new Fuse(things, {
-    keys: ['title', 'description', 'onThisSite', 'categories'],
-  })
+  const fuse = new Fuse(filteredThings, { keys: ['title', 'description'] })
+  const searchResults = fuse.search(searchQuery)
 
-  const results = fuse.search({ $and: expressions })
-  return results.map((result) => result.item)
+  return searchResults.map((result) => result.item)
 }
 
 function sortThingsDescending(

--- a/config/contentlayer/document-types/CoolThing.ts
+++ b/config/contentlayer/document-types/CoolThing.ts
@@ -73,6 +73,11 @@ export const CoolThing = defineDocumentType(() => ({
       description: 'Indicates whether the thing is no longer cool :(',
       required: true,
     },
+    archiveReason: {
+      type: 'string',
+      description: 'The reason the thing was archived',
+      required: false,
+    },
   },
   computedFields: {
     id: {

--- a/content/cool-things/fusejs.mdx
+++ b/content/cool-things/fusejs.mdx
@@ -9,5 +9,6 @@ categories:
 onThisSite: true
 coolFactor: 10
 addedDate: 2023-04-29
-isArchived: false
+isArchived: true
+archiveReason: Fuse.js has been archived due to its lack of active maintenance and an issue concerning exact match filtering, which compromises its reliability for search and filter UIs.
 ---


### PR DESCRIPTION
A potential scoring issue in Fuse.js means that the 'exact match' filtering used for the category filter didn't behave as expected.

See related GitHub issues:

- https://github.com/krisk/Fuse/issues/717
- https://github.com/krisk/Fuse/issues/545
- https://github.com/krisk/Fuse/issues/408

This PR replaces Fuse.js exact matching with custom filter functions