### PR TITLE
Cool stuff modal

### DIFF
--- a/src/app/cool-stuff/@modal/(..)cool-stuff/[id]/page.tsx
+++ b/src/app/cool-stuff/@modal/(..)cool-stuff/[id]/page.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { getCoolThing } from '@/app/cool-stuff/utils'
+import { Modal } from '@/components/Modal'
+import { CoolThingDetails } from '@/components/cool-things/CoolThingDetails'
+import { useRouter } from 'next/navigation'
+
+export default function CoolThingModal({ params }: { params: { id: string } }) {
+  const thing = getCoolThing(params.id)
+  const router = useRouter()
+
+  return (
+    <Modal show={true} onClose={() => router.back()}>
+      <CoolThingDetails className="max-w-3xl" thing={thing} headingLevel="h2" />
+    </Modal>
+  )
+}

--- a/src/app/cool-stuff/@modal/default.tsx
+++ b/src/app/cool-stuff/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function DefaultModal() {
+  return null
+}

--- a/src/app/cool-stuff/[id]/page.tsx
+++ b/src/app/cool-stuff/[id]/page.tsx
@@ -1,12 +1,7 @@
 import { CoolThing, allCoolThings } from 'contentlayer/generated'
-import { Title } from '@/components/Title'
 import { Metadata } from 'next'
-import { formatDate } from '@/utils/format-date'
-import { Markdown } from '@/components/Markdown'
-import { CoolThingIcon } from '@/components/cool-things/CoolThingIcon'
-import { Prose } from '@/components/Prose'
-import { CustomLink } from '@/components/CustomLink'
 import { getCoolThing } from '../utils'
+import { CoolThingDetails } from '@/components/cool-things/CoolThingDetails'
 
 interface Params {
   id: string
@@ -42,84 +37,16 @@ export function generateMetadata({ params }: { params: Params }): Metadata {
   }
 }
 
-const numberFormat = new Intl.NumberFormat()
-
 export default function CoolThing({ params }: { params: Params }) {
   const thing = getCoolThing(params.id)
 
   return (
     <div className="px-4 py-16 sm:px-8 sm:py-20 xl:py-24">
-      <article className="mx-auto max-w-3xl">
-        <header className="flex flex-col gap-8 sm:flex-row lg:gap-12">
-          <div className="shrink grow">
-            <Title>{thing.title}</Title>
-
-            <Prose className="mt-4">
-              <p>{thing.description}</p>
-            </Prose>
-          </div>
-
-          <div className="shrink-0 sm:order-first">
-            <CoolThingIcon
-              className="md:aspect-square"
-              thing={thing}
-              size="large"
-            />
-          </div>
-        </header>
-
-        <Prose className="mt-10">
-          <table className="table-fixed">
-            <tbody>
-              <TableRow header="Date Added">
-                <time dateTime={thing.addedDate}>
-                  {formatDate(thing.addedDate)}
-                </time>
-              </TableRow>
-
-              <TableRow header="Category">
-                {thing.categories.join(', ')}
-              </TableRow>
-
-              <TableRow header="Cool Factor">
-                {numberFormat.format(thing.coolFactor)}
-              </TableRow>
-
-              <TableRow header="On This Site">
-                {thing.onThisSite ? 'Yes' : 'No'}
-              </TableRow>
-
-              <TableRow header="Website">
-                <div className="truncate">
-                  <CustomLink
-                    href={thing.websiteUrl}
-                    showHostnameIfExternal={true}
-                  />
-                </div>
-              </TableRow>
-            </tbody>
-          </table>
-        </Prose>
-
-        <Markdown className="mt-10" code={thing.body.code} />
-      </article>
+      <CoolThingDetails
+        className="mx-auto max-w-3xl"
+        thing={thing}
+        headingLevel="h1"
+      />
     </div>
-  )
-}
-
-function TableRow({
-  header,
-  children,
-}: {
-  header: string
-  children: React.ReactNode
-}) {
-  return (
-    <tr>
-      <th className="w-28 whitespace-nowrap md:w-1/2" scope="row">
-        {header}
-      </th>
-      <td className="text-right md:w-1/2 md:text-left">{children}</td>
-    </tr>
   )
 }

--- a/src/app/cool-stuff/layout.tsx
+++ b/src/app/cool-stuff/layout.tsx
@@ -1,0 +1,11 @@
+export default function CoolStuffLayout(props: {
+  children: React.ReactNode
+  modal: React.ReactNode
+}) {
+  return (
+    <>
+      {props.children}
+      {props.modal}
+    </>
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  html:has(dialog[open]) {
+    @apply overflow-hidden;
+  }
+}
+
 @layer components {
   [data-rehype-pretty-code-fragment] {
     @apply relative;

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -25,7 +25,7 @@ export interface BadgeProps {
 }
 
 const badge = cva(
-  'inline-flex items-center rounded-md font-medium ring-1 ring-inset',
+  'inline-flex items-center rounded-md font-medium ring-1 ring-inset select-none',
   {
     variants: {
       color: {

--- a/src/components/Heading.tsx
+++ b/src/components/Heading.tsx
@@ -7,16 +7,16 @@ export type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 
 export type HeadingProps = React.HTMLAttributes<HTMLHeadingElement> & {
   level: HeadingLevel
-  balanceText?: boolean
+  balanced?: boolean
 }
 
 export function Heading({
   level: Tag,
   children,
-  balanceText,
+  balanced,
   ...props
 }: HeadingProps) {
-  const Wrapper = balanceText ? Balancer : Fragment
+  const Wrapper = balanced ? Balancer : Fragment
 
   return (
     <Tag {...props} className={clsx(props.className, props.id && 'group')}>

--- a/src/components/Heading.tsx
+++ b/src/components/Heading.tsx
@@ -1,17 +1,27 @@
 import { Link as LinkIcon } from '@/assets/phosphor-icons'
 import clsx from 'clsx'
+import { Fragment } from 'react'
+import Balancer from 'react-wrap-balancer'
 
 export type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 
 export type HeadingProps = React.HTMLAttributes<HTMLHeadingElement> & {
   level: HeadingLevel
+  balanceText?: boolean
 }
 
-export function Heading({ level: Tag, children, ...props }: HeadingProps) {
+export function Heading({
+  level: Tag,
+  children,
+  balanceText,
+  ...props
+}: HeadingProps) {
+  const Wrapper = balanceText ? Balancer : Fragment
+
   return (
     <Tag {...props} className={clsx(props.className, props.id && 'group')}>
       {props.id && <HeadingAnchorLink id={props.id} />}
-      {children}
+      <Wrapper>{children}</Wrapper>
     </Tag>
   )
 }

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,0 +1,36 @@
+import { IconProps } from '@/assets/phosphor-icons'
+import clsx from 'clsx'
+
+export interface IconButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  className?: string
+  label: string
+  icon: React.ComponentType<IconProps>
+  onClick: VoidFunction
+}
+
+export function IconButton({
+  className,
+  label,
+  icon: Icon,
+  onClick,
+  ...props
+}: IconButtonProps) {
+  return (
+    <button
+      className={clsx(
+        'group flex h-8 w-8 items-center justify-center rounded-full bg-white shadow-md shadow-gray-800/5 ring-1 ring-gray-900/5 transition dark:border dark:border-gray-700/50 dark:bg-gray-800 dark:ring-0 dark:ring-white/10 dark:hover:border-gray-700 dark:hover:ring-white/20',
+        className
+      )}
+      aria-label={label}
+      onClick={onClick}
+      {...props}
+    >
+      <Icon
+        className="h-4 w-4 text-gray-500 transition group-hover:scale-110 group-hover:text-gray-700 dark:text-gray-500 dark:group-hover:text-gray-400"
+        aria-hidden={true}
+        weight="bold"
+      />
+    </button>
+  )
+}

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -19,7 +19,7 @@ export function IconButton({
   return (
     <button
       className={clsx(
-        'group flex h-8 w-8 items-center justify-center rounded-full bg-white shadow-md shadow-gray-800/5 ring-1 ring-gray-900/5 transition dark:border dark:border-gray-700/50 dark:bg-gray-800 dark:ring-0 dark:ring-white/10 dark:hover:border-gray-700 dark:hover:ring-white/20',
+        'group flex h-8 w-8 items-center justify-center rounded-full bg-white/70 shadow-md shadow-gray-800/5 ring-1 ring-gray-900/5 backdrop-blur-md transition dark:border dark:border-gray-700/50 dark:bg-gray-800/70 dark:ring-0 dark:ring-white/10 dark:hover:border-gray-700 dark:hover:ring-white/20',
         className
       )}
       aria-label={label}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,67 @@
+'use client'
+import { useEffect, useRef, useState } from 'react'
+import { IconButton } from './IconButton'
+import { X } from '@/assets/phosphor-icons'
+
+export interface ModalProps {
+  children: React.ReactNode
+  show: boolean
+  onClose: VoidFunction
+}
+
+export function Modal({ children, show, onClose }: ModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    if (!dialogRef.current) return
+
+    if (show) {
+      dialogRef.current.showModal()
+    } else {
+      dialogRef.current.close()
+    }
+  }, [show])
+
+  return (
+    <dialog
+      className="m-auto w-full max-w-full bg-transparent p-0 text-inherit backdrop:bg-gray-300/30 backdrop:backdrop-blur-md dark:backdrop:bg-gray-700/30 sm:w-fit sm:p-5"
+      ref={dialogRef}
+      onClose={onClose}
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full rounded-lg bg-body-light p-10 px-5 py-6 dark:bg-body-dark sm:w-fit sm:p-12"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <IconButton
+          className="absolute right-3 top-3.5 sm:right-4 sm:top-4"
+          label="Close modal"
+          icon={X}
+          onClick={onClose}
+          autoFocus={true}
+        />
+
+        {children}
+      </div>
+    </dialog>
+  )
+}
+
+export function ModalExample() {
+  const [showModal, setShowModal] = useState(false)
+
+  return (
+    <>
+      <button
+        className="rounded-lg border p-4"
+        onClick={() => setShowModal(true)}
+      >
+        Show Modal
+      </button>
+
+      <Modal show={showModal} onClose={() => setShowModal(false)}>
+        This is the modal
+      </Modal>
+    </>
+  )
+}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -24,24 +24,25 @@ export function Modal({ children, show, onClose }: ModalProps) {
 
   return (
     <dialog
-      className="m-auto w-full max-w-full bg-transparent p-0 text-inherit backdrop:bg-gray-300/30 backdrop:backdrop-blur-md dark:backdrop:bg-gray-700/30 sm:w-fit sm:p-5"
+      className="fixed inset-0 flex h-full max-h-full w-full max-w-full flex-col overflow-visible bg-transparent p-0 text-inherit backdrop:bg-gray-300/30 backdrop:backdrop-blur-md dark:backdrop:bg-gray-700/20 sm:max-h-none sm:overflow-y-scroll sm:p-5"
       ref={dialogRef}
       onClose={onClose}
       onClick={onClose}
     >
       <div
-        className="relative w-full rounded-lg bg-body-light p-10 px-5 py-6 dark:bg-body-dark sm:w-fit sm:p-12"
+        className="h-full w-full overflow-y-scroll bg-body-light shadow-xl dark:bg-body-dark sm:m-auto sm:h-fit sm:w-fit sm:overflow-y-visible sm:rounded-lg"
         onClick={(event) => event.stopPropagation()}
       >
-        <IconButton
-          className="absolute right-3 top-3.5 sm:right-4 sm:top-4"
-          label="Close modal"
-          icon={X}
-          onClick={onClose}
-          autoFocus={true}
-        />
+        <header className="sticky top-0 flex justify-end px-5 py-4 sm:px-8 sm:py-8">
+          <IconButton
+            label="Close modal"
+            icon={X}
+            onClick={onClose}
+            autoFocus={true}
+          />
+        </header>
 
-        {children}
+        <div className="px-5 pb-16 sm:px-12 sm:pb-24">{children}</div>
       </div>
     </dialog>
   )

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -33,7 +33,7 @@ export function Modal({ children, show, onClose }: ModalProps) {
         className="h-full w-full overflow-y-scroll bg-body-light shadow-xl dark:bg-body-dark sm:m-auto sm:h-fit sm:w-fit sm:overflow-y-visible sm:rounded-lg"
         onClick={(event) => event.stopPropagation()}
       >
-        <header className="sticky top-0 flex justify-end px-5 py-4 sm:px-8 sm:py-8">
+        <header className="sticky top-0 flex justify-end px-5 py-4 sm:px-8 sm:pt-8">
           <IconButton
             label="Close modal"
             icon={X}
@@ -42,7 +42,7 @@ export function Modal({ children, show, onClose }: ModalProps) {
           />
         </header>
 
-        <div className="px-5 pb-16 sm:px-12 sm:pb-24">{children}</div>
+        <div className="px-5 pb-16 sm:px-12">{children}</div>
       </div>
     </dialog>
   )

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -15,7 +15,7 @@ export function Title({ className, headingLevel, children }: TitleProps) {
         className
       )}
       level={headingLevel || 'h1'}
-      balanceText={true}
+      balanced={true}
     >
       {children}
     </Heading>

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -1,20 +1,23 @@
 import clsx from 'clsx'
-import Balancer from 'react-wrap-balancer'
+import { Heading, HeadingLevel } from './Heading'
 
 export interface TitleProps {
   className?: string
+  headingLevel?: HeadingLevel
   children: React.ReactNode
 }
 
-export function Title({ className, children }: TitleProps) {
+export function Title({ className, headingLevel, children }: TitleProps) {
   return (
-    <h1
+    <Heading
       className={clsx(
         'text-4xl font-semibold tracking-tight sm:text-5xl',
         className
       )}
+      level={headingLevel || 'h1'}
+      balanceText={true}
     >
-      <Balancer>{children}</Balancer>
-    </h1>
+      {children}
+    </Heading>
   )
 }

--- a/src/components/cool-things/CoolThingDetails.tsx
+++ b/src/components/cool-things/CoolThingDetails.tsx
@@ -1,0 +1,94 @@
+import { CoolThing } from 'contentlayer/generated'
+import { Prose } from '../Prose'
+import { Title } from '../Title'
+import { CoolThingIcon } from './CoolThingIcon'
+import { Markdown } from '../Markdown'
+import { CustomLink } from '../CustomLink'
+import { formatDate } from '@/utils/format-date'
+import { HeadingLevel } from '../Heading'
+
+export interface CoolThingDetailsProps {
+  className?: string
+  thing: CoolThing
+  headingLevel: HeadingLevel
+}
+
+export function CoolThingDetails({
+  className,
+  thing,
+  headingLevel,
+}: CoolThingDetailsProps) {
+  return (
+    <article className={className}>
+      <header className="flex flex-col gap-8 sm:flex-row lg:gap-12">
+        <div className="shrink grow">
+          <Title headingLevel={headingLevel}>{thing.title}</Title>
+
+          <Prose className="mt-4">
+            <p>{thing.description}</p>
+          </Prose>
+        </div>
+
+        <div className="shrink-0 sm:order-first">
+          <CoolThingIcon
+            className="md:aspect-square"
+            thing={thing}
+            size="large"
+          />
+        </div>
+      </header>
+
+      <Prose className="mt-10">
+        <table className="table-fixed">
+          <tbody>
+            <TableRow header="Date Added">
+              <time dateTime={thing.addedDate}>
+                {formatDate(thing.addedDate)}
+              </time>
+            </TableRow>
+
+            <TableRow header="Category">{thing.categories.join(', ')}</TableRow>
+
+            <TableRow header="Cool Factor">
+              {numberFormat.format(thing.coolFactor)}
+            </TableRow>
+
+            <TableRow header="On This Site">
+              {thing.onThisSite ? 'Yes' : 'No'}
+            </TableRow>
+
+            <TableRow header="Website">
+              <div className="truncate">
+                <CustomLink
+                  href={thing.websiteUrl}
+                  showHostnameIfExternal={true}
+                />
+              </div>
+            </TableRow>
+          </tbody>
+        </table>
+      </Prose>
+
+      <Markdown className="mt-10" code={thing.body.code} />
+    </article>
+  )
+}
+
+const numberFormat = new Intl.NumberFormat()
+
+function TableRow({
+  header,
+  children,
+}: {
+  header: string
+  children: React.ReactNode
+}) {
+  return (
+    <tr>
+      <th className="w-28 whitespace-nowrap md:w-1/2" scope="row">
+        {header}
+      </th>
+      <td className="text-right md:w-1/2 md:text-left">{children}</td>
+    </tr>
+  )
+}

--- a/src/components/cool-things/CoolThingListCategoryFilter.tsx
+++ b/src/components/cool-things/CoolThingListCategoryFilter.tsx
@@ -54,7 +54,7 @@ interface CategoryFilterOptionProps {
 }
 
 const option = cva(
-  'cursor-pointer rounded-full border px-4 py-1.5 text-sm font-medium shadow-sm transition-colors',
+  'cursor-pointer rounded-full border px-4 py-1.5 text-sm font-medium shadow-sm transition-colors select-none',
   {
     variants: {
       checked: {


### PR DESCRIPTION
Use a [parallel route](https://nextjs.org/docs/app/building-your-application/routing/parallel-routes) and [route interception](https://nextjs.org/docs/app/building-your-application/routing/intercepting-routes) to add a modal to the `/cool-stuff` page.

- Update `Title` to use `Heading` with a configurable `headingLevel`.
- Extract `CoolThingDetails` component.
- Add `Modal` component using HTML `<dialog>`.
- Add `IconButton` component.